### PR TITLE
Replace a vulnerable regexp with dumb, faster code

### DIFF
--- a/lib/mailparser.js
+++ b/lib/mailparser.js
@@ -208,7 +208,6 @@ MailParser.prototype._process = function(finalPart) {
                 this._remainder = force1MbLines(this._remainder);
             else
                 this._remainder = this._remainder.replace(/(.{1048576}(?!\r?\n|\r))/g, "$&\n");
-
         }
     }
 
@@ -262,6 +261,8 @@ MailParser.prototype._process = function(finalPart) {
 };
 
 function force1MbLines(str) {
+    const oneMb = 1048576;
+
     // this used to be: str.replace(/(.{1048576}(?!\r?\n|\r))/g, "$&\n");
     // but regexp performance is terrible with such long strings
     // the regexp uses "x(?!y)" which means "x not followed by y"
@@ -269,7 +270,6 @@ function force1MbLines(str) {
     if (str.length < oneMb)
         return str;
 
-    const oneMb = 1048576;
     let current = str;
     const chunks = [];
 
@@ -277,7 +277,7 @@ function force1MbLines(str) {
     // however, we must check if there's not already a line-break immediately afterwards
     // it could cause the message to be partially imported
     while (current.length >= oneMb) {
-        const chunk = str.substring(0, oneMb);
+        let chunk = str.substring(0, oneMb);
         const rest = str.substring(oneMb);
 
         if (rest.substring(0, 2) === '\r\n') {

--- a/lib/mailparser.js
+++ b/lib/mailparser.js
@@ -204,7 +204,11 @@ MailParser.prototype._process = function(finalPart) {
         this._remainder = lines.pop();
         // force line to 1MB chunks if needed
         if (this._remainder.length > 1048576) {
-            this._remainder = force1MbChunks(this._remainder);
+            if (this.options.fastChunking)
+                this._remainder = force1MbLines(this._remainder);
+            else
+                this._remainder = this._remainder.replace(/(.{1048576}(?!\r?\n|\r))/g, "$&\n");
+
         }
     }
 
@@ -257,7 +261,7 @@ MailParser.prototype._process = function(finalPart) {
 
 };
 
-function force1MbChunks(str) {
+function force1MbLines(str) {
     // this used to be: str.replace(/(.{1048576}(?!\r?\n|\r))/g, "$&\n");
     // but regexp performance is terrible with such long strings
     // the regexp uses "x(?!y)" which means "x not followed by y"

--- a/lib/mailparser.js
+++ b/lib/mailparser.js
@@ -204,7 +204,7 @@ MailParser.prototype._process = function(finalPart) {
         this._remainder = lines.pop();
         // force line to 1MB chunks if needed
         if (this._remainder.length > 1048576) {
-            this._remainder = this._remainder.replace(/(.{1048576}(?!\r?\n|\r))/g, "$&\n");
+            this._remainder = force1MbChunks(this._remainder);
         }
     }
 
@@ -256,6 +256,49 @@ MailParser.prototype._process = function(finalPart) {
 
 
 };
+
+function force1MbChunks(str) {
+    // this used to be: str.replace(/(.{1048576}(?!\r?\n|\r))/g, "$&\n");
+    // but regexp performance is terrible with such long strings
+    // the regexp uses "x(?!y)" which means "x not followed by y"
+
+    if (str.length < oneMb)
+        return str;
+
+    const oneMb = 1048576;
+    let current = str;
+    const chunks = [];
+
+    // force line-breaks every 1Mb
+    // however, we must check if there's not already a line-break immediately afterwards
+    // it could cause the message to be partially imported
+    while (current.length >= oneMb) {
+        const chunk = str.substring(0, oneMb);
+        const rest = str.substring(oneMb);
+
+        if (rest.substring(0, 2) === '\r\n') {
+            // rest is \r\n...
+            chunk = chunk + '\r\n';
+            rest = rest.substring(2);
+        } else if (rest[0] === '\n') {
+            // rest is \n...
+            chunk = chunk + '\n';
+            rest = rest.substring(1);
+        } else if (rest[0] === '\r') {
+            // rest is \r...
+            chunk = chunk + '\r';
+            rest = rest.substring(1);
+        } else {
+            // otherwise, force a line-break
+            chunk = chunk + '\n';
+        }
+
+        current = rest;
+        chunks.push(chunk);
+    }
+
+    return chunks.join('');
+}
 
 /**
  * <p>Processes a line while in header state</p>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "front-mailparser",
   "description": "Asynchronous and non-blocking parser for mime encoded e-mail messages",
-  "version": "0.6.1-1",
+  "version": "0.6.1-2",
   "author": "Andris Reinman",
   "maintainers": [{
     "name": "andris",


### PR DESCRIPTION
The new code only runs if the `fastChunking` option is passed.