### PR TITLE
Treat content type ISO-8859-8-I as ISO-8859-8

### DIFF
--- a/lib/mailparser.js
+++ b/lib/mailparser.js
@@ -778,7 +778,7 @@ MailParser.prototype._parseContentType = function(value) {
                 // ANSI_X3.4-1968 and ANSI_X3.4-1986 are aliases for ASCII.
                 // See http://en.wikipedia.org/wiki/ASCII#Aliases
                 value.charset = "utf-8";
-            } else if (value.charset === 'iso-8859-8-i') { // Jeremy Bogatirsky 12/2019: ugly fix to support some badly encoded Hebrew messages.
+            } else if (value.charset === 'iso-8859-8-i') { // 12/2019: ugly fix to support Hebrew messages using wrong encoding
                 value.charset === 'iso-8859-8'
             }
             this._currentNode.meta.charset = value.charset;
@@ -1019,7 +1019,7 @@ MailParser.prototype._finalizeContents = function() {
 
         if (!this._currentNode.attachment) {
 
-            // Jeremy Bogatirsky 12/2019: ugly fix to support some badly encoded Hebrew messages.
+            // 12/2019: ugly fix to support Hebrew messages using wrong encoding
             if (this._currentNode.meta.charset === 'iso-8859-8-i')
               this._currentNode.meta.charset = 'iso-8859-8';
 
@@ -1416,7 +1416,7 @@ MailParser.prototype._convertString = function(value, fromCharset, toCharset) {
     toCharset = (toCharset || "utf-8").toUpperCase();
     fromCharset = (fromCharset || "utf-8").toUpperCase();
 
-    // Jeremy Bogatirsky 12/2019: ugly fix to support some badly encoded Hebrew messages.
+    // 12/2019: ugly fix to support Hebrew messages using wrong encoding
     if (fromCharset === 'ISO-8859-8-I')
       fromCharset = 'ISO-8859-8';
 
@@ -1462,8 +1462,8 @@ MailParser.prototype._encodeString = function(value) {
 MailParser.prototype._replaceMimeWords = function(value) {
     return value.
     replace(/(=\?[^?]+\?[QqBb]\?[^?]*\?=)\s+(?==\?[^?]+\?[QqBb]\?[^?]*\?=)/g, "$1"). // join mimeWords
-    replace('iso-8859-8-i', 'iso-8859-8'). // Jeremy Bogatirsky 12/2019: ugly fix to support some badly encoded Hebrew messages.
-    replace('ISO-8859-8-I', 'ISO-8859-8'). // Jeremy Bogatirsky 12/2019: ugly fix to support some badly encoded Hebrew messages.
+    replace('iso-8859-8-i', 'iso-8859-8'). // 12/2019: ugly fix to support Hebrew messages using wrong encoding
+    replace('ISO-8859-8-I', 'ISO-8859-8'). // 12/2019: ugly fix to support Hebrew messages using wrong encoding
     replace(/\=\?[^?]+\?[QqBb]\?[^?]*\?=/g, (function(a) {
         return mimelib.decodeMimeWord(a.replace(/\s/g, ''));
     }).bind(this));
@@ -1582,7 +1582,7 @@ MailParser.prototype._detectHTMLCharset = function(html) {
         charset = (meta[1] || "").trim().toLowerCase();
     }
 
-    // Jeremy Bogatirsky 12/2019: ugly fix to support some badly encoded Hebrew messages.
+    // 12/2019: ugly fix to support Hebrew messages using wrong encoding
     if (charset === 'iso-8859-8-i')
         charset = 'iso-8859-8';
 

--- a/lib/mailparser.js
+++ b/lib/mailparser.js
@@ -778,6 +778,8 @@ MailParser.prototype._parseContentType = function(value) {
                 // ANSI_X3.4-1968 and ANSI_X3.4-1986 are aliases for ASCII.
                 // See http://en.wikipedia.org/wiki/ASCII#Aliases
                 value.charset = "utf-8";
+            } else if (value.charset === 'iso-8859-8-i') { // Jeremy Bogatirsky 12/2019: ugly fix to support some badly encoded Hebrew messages.
+                value.charset === 'iso-8859-8'
             }
             this._currentNode.meta.charset = value.charset;
         }
@@ -1016,6 +1018,10 @@ MailParser.prototype._finalizeContents = function() {
     if (this._currentNode.content) {
 
         if (!this._currentNode.attachment) {
+
+            // Jeremy Bogatirsky 12/2019: ugly fix to support some badly encoded Hebrew messages.
+            if (this._currentNode.meta.charset === 'iso-8859-8-i')
+              this._currentNode.meta.charset = 'iso-8859-8';
 
             if (this._currentNode.meta.contentType == "text/html" && !this._currentNode.meta.charset) {
                 this._currentNode.meta.charset = this._detectHTMLCharset(this._currentNode.content) || this.options.defaultCharset || "iso-8859-1";
@@ -1410,6 +1416,10 @@ MailParser.prototype._convertString = function(value, fromCharset, toCharset) {
     toCharset = (toCharset || "utf-8").toUpperCase();
     fromCharset = (fromCharset || "utf-8").toUpperCase();
 
+    // Jeremy Bogatirsky 12/2019: ugly fix to support some badly encoded Hebrew messages.
+    if (fromCharset === 'ISO-8859-8-I')
+      fromCharset = 'ISO-8859-8';
+
     value = typeof value == "string" ? new Buffer(value, "binary") : value;
 
     if (toCharset == fromCharset) {
@@ -1452,6 +1462,8 @@ MailParser.prototype._encodeString = function(value) {
 MailParser.prototype._replaceMimeWords = function(value) {
     return value.
     replace(/(=\?[^?]+\?[QqBb]\?[^?]*\?=)\s+(?==\?[^?]+\?[QqBb]\?[^?]*\?=)/g, "$1"). // join mimeWords
+    replace('iso-8859-8-i', 'iso-8859-8'). // Jeremy Bogatirsky 12/2019: ugly fix to support some badly encoded Hebrew messages.
+    replace('ISO-8859-8-I', 'ISO-8859-8'). // Jeremy Bogatirsky 12/2019: ugly fix to support some badly encoded Hebrew messages.
     replace(/\=\?[^?]+\?[QqBb]\?[^?]*\?=/g, (function(a) {
         return mimelib.decodeMimeWord(a.replace(/\s/g, ''));
     }).bind(this));
@@ -1569,6 +1581,10 @@ MailParser.prototype._detectHTMLCharset = function(html) {
     if (!charset && (meta = html.match(/<meta\s+charset=["']([^'"<\/]*?)["']/i))) {
         charset = (meta[1] || "").trim().toLowerCase();
     }
+
+    // Jeremy Bogatirsky 12/2019: ugly fix to support some badly encoded Hebrew messages.
+    if (charset === 'iso-8859-8-i')
+        charset = 'iso-8859-8';
 
     return charset;
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "front-mailparser",
   "description": "Asynchronous and non-blocking parser for mime encoded e-mail messages",
-  "version": "0.6.1-2",
+  "version": "0.6.1-3",
   "author": "Andris Reinman",
   "maintainers": [{
     "name": "andris",


### PR DESCRIPTION
Content type ISO-8859-8-I is not standard. It's a variation of ISO-8859-8 and thus not recognized by `iconv`.
Since we cannot ask our customers' customer to correctly configured their email software clients and/or servers, let's add an ugly fix.
And `mailparser` is easier to "fix" than `iconv`.
See [Front conversation](https://front.frontapp.com/open/cnv_3t2vxfn) and [JIRA issue](https://frontjira.atlassian.net/browse/PB-12151).