### PR TITLE
Handle malformed content-type with date

### DIFF
--- a/lib/mailparser.js
+++ b/lib/mailparser.js
@@ -508,7 +508,14 @@ MailParser.prototype._processHeaderLine = function(pos) {
 
     switch (key) {
         case "content-type":
-            this._parseContentType(value);
+            // 12/2019: ugly fix to handle a case where a date is inserted in the Content-Type header
+            const invalidDateHeaderIndex = value.indexOf('\\r\\nDate:');
+            if (invalidDateHeaderIndex === -1) {
+                this._parseContentType(value);
+            } else {
+                const contentTypeValue = value.substring(0, invalidDateHeaderIndex);
+                this._parseContentType(contentTypeValue);
+            }
             break;
         case "mime-version":
             this._currentNode.useMIME = true;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "front-mailparser",
   "description": "Asynchronous and non-blocking parser for mime encoded e-mail messages",
-  "version": "0.6.1-3",
+  "version": "0.6.1-4",
   "author": "Andris Reinman",
   "maintainers": [{
     "name": "andris",


### PR DESCRIPTION
See JIRA [PB-12175](https://frontjira.atlassian.net/browse/PB-12175).
See message https://hq.frontapp.com/messages/7029421827

The `content-type` header looks like:
```
content-type: "multipart/report; report-type=delivery-status; boundary="5607a93da502b027"\r\nDate: Mon, 17 Jun 2019 04:00:42 UTC"
```