### PR TITLE
Fully override the content-type

### DIFF
--- a/lib/mailparser.js
+++ b/lib/mailparser.js
@@ -510,12 +510,10 @@ MailParser.prototype._processHeaderLine = function(pos) {
         case "content-type":
             // 12/2019: ugly fix to handle a case where a date is inserted in the Content-Type header
             const invalidDateHeaderIndex = value.indexOf('\\r\\nDate:');
-            if (invalidDateHeaderIndex === -1) {
-                this._parseContentType(value);
-            } else {
-                const contentTypeValue = value.substring(0, invalidDateHeaderIndex);
-                this._parseContentType(contentTypeValue);
-            }
+            if (invalidDateHeaderIndex !== -1)
+              value = value.substring(0, invalidDateHeaderIndex);
+
+            this._parseContentType(value);
             break;
         case "mime-version":
             this._currentNode.useMIME = true;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "front-mailparser",
   "description": "Asynchronous and non-blocking parser for mime encoded e-mail messages",
-  "version": "0.6.1-4",
+  "version": "0.6.1-5",
   "author": "Andris Reinman",
   "maintainers": [{
     "name": "andris",


### PR DESCRIPTION
The previous version was fixing the parsing of the message content but the final content-type header was keeping the incorrect value.
This PR makes sure the content-type header is overwritten by the new value.